### PR TITLE
don't allow blank comments

### DIFF
--- a/app/models/flyover_comments/comment.rb
+++ b/app/models/flyover_comments/comment.rb
@@ -18,6 +18,7 @@ module FlyoverComments
 
     validates :commentable, presence: true
     validates :commenter, presence: true
+    validates :content, presence: true
 
     attr_accessor :all_flags_reviewed
 

--- a/app/views/flyover_comments/comments/_form.html.erb
+++ b/app/views/flyover_comments/comments/_form.html.erb
@@ -8,7 +8,7 @@
                     placeholder: form_opts[:placeholder_text] || t('.comment_content_placeholder') %>
   </div>
   <div class="flyover-comment-submit">
-    <%= f.submit t('.submit'), class: "btn btn-primary", data: { disable_with: t('.submitting') } %>
+    <%= f.submit t('.submit'), class: "btn btn-primary", data: { disable_with: t('.submitting') }, disabled: true %>
     <%= link_to t('.cancel'), "#", class: "flyover-comment-cancel hide" %>
   </div>
 <% end %>


### PR DESCRIPTION
We already have javascript to enable/disable the comment submit button when there is/isn't content in the comment.